### PR TITLE
Update notebook version for known CVE's

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ mistune==0.8.3
 nbconvert==5.4.0
 nbformat==4.4.0
 networkx==2.1
-notebook==5.7.0
+notebook==5.7.2
 numpy==1.15.2
 opencv-python==3.4.3.18
 pandas==0.23.4


### PR DESCRIPTION
GitHub alerted of a known vulnerability with the defined notebook version within requirements.txt. The linked CVE's were as below : 

https://nvd.nist.gov/vuln/detail/CVE-2018-19351
https://nvd.nist.gov/vuln/detail/CVE-2018-19352

Updating notebook version accordingly.