### PR TITLE
Corrected docker build issue for jupyter image

### DIFF
--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -1,0 +1,3 @@
+FROM edhenry/chexnet-jupyter:latest
+
+COPY ["./CheXNet Workflow Example.ipynb", "/notebooks/jupyter_env"]

--- a/playbook/roles/jupyter_env/docker-compose.yml
+++ b/playbook/roles/jupyter_env/docker-compose.yml
@@ -3,13 +3,12 @@
 version: '2'
 services:
   ui:
-    image: edhenry/chexnet-jupyter:0.1
+    image: edhenry/chexnet-jupyter:latest
+    build: .
     networks: 
       kafka_data-stack-net:
         ipv4_address: 172.23.0.20
     entrypoint: [jupyter, notebook, --allow-root]
-    volumes:
-      - /home/ed/Documents/code/chexnet:/notebooks/jupyter_env
     environment:
       JUPYTER_TOKEN: "demo"
 


### PR DESCRIPTION
Changes allow us to properly package the jupyter notebook in the container image.

Built image using 
`sudo docker build -t edhenry/chexnet-jupyter:latest -f Dockerfile.jupyter .`

Following this, pushed it to the Dockerhub repo.  Confirmed that this works by issuing the proper ansible commands and accessing the jupyternotebook server instance.